### PR TITLE
Fix CSS to make code snippets visible

### DIFF
--- a/src/main/sass/spring/_layout.scss
+++ b/src/main/sass/spring/_layout.scss
@@ -261,7 +261,7 @@ pre.highlight {
   border: 1px solid #d9d9d9;
   overflow-x: scroll;
   code {
-    color: #222;
+    color: #eee;
   }
   color: #222;
 }


### PR DESCRIPTION
With current css code snippets in spring docs are invisible.
![image](https://user-images.githubusercontent.com/317662/84493222-b8502f00-aca7-11ea-9a8a-8cc131220975.png)
With change of that element it would be correctly displayed:
![image](https://user-images.githubusercontent.com/317662/84493272-c9993b80-aca7-11ea-84fb-22c075f819fe.png)
Tested with Chrome Dev Tools:
![image](https://user-images.githubusercontent.com/317662/84493312-d9b11b00-aca7-11ea-917a-18990d38f948.png)
Here you can find the use case:
https://cloud.spring.io/spring-cloud-commons/2.2.x/reference/html/#customizing-bootstrap-property-sources
